### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt eol=crlf


### PR DESCRIPTION
Forces GitHub to download the levels with Windows line endings (so 5b can read them).